### PR TITLE
Docs: Fix incorrect H2 location in project  README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Creates a new `Vrzno` object that holds a reference to Javascript's `globalThis`
 <?php
 $window = new Vrzno;
 ```
+
 ## PHP Functions
 
 ### `vrzno_await($promise)`


### PR DESCRIPTION
Although several Markdown parsers don't need a newline before an H2 `##`, Pandoc does seem to have issues with it.

This causes an issue in the documentation website (https://php-wasm.seanmorr.is/extensions/vrzno.html)

![image](https://github.com/user-attachments/assets/b0789f44-2c14-471f-bd52-77b67ca3ef8c)

This MR add the required newline to resolve that issue.